### PR TITLE
Update to micropython 1.24.1

### DIFF
--- a/boards/CUSTOM_ESP32/CMakeLists.txt
+++ b/boards/CUSTOM_ESP32/CMakeLists.txt
@@ -25,6 +25,9 @@ endforeach()
 configure_file(${CMAKE_BINARY_DIR}/sdkconfig.combined.in ${CMAKE_BINARY_DIR}/sdkconfig.combined COPYONLY)
 set(SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.combined)
 
+# Use the default linker fragments unless you need otherwise
+set(MICROPY_USER_LDFRAGMENTS ${MICROPY_PORT_DIR}/main_${IDF_TARGET}/linker.lf)
+
 # Include main IDF cmake file and define the project.
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(micropython)

--- a/boards/CUSTOM_ESP32/mpconfigboard.cmake
+++ b/boards/CUSTOM_ESP32/mpconfigboard.cmake
@@ -6,6 +6,14 @@ set(SDKCONFIG_DEFAULTS
     ${MICROPY_PORT_DIR}/boards/sdkconfig.base
     ${MICROPY_PORT_DIR}/boards/sdkconfig.ble
 )
+include($ENV{IDF_PATH}/tools/cmake/version.cmake)
+set(IDF_VERSION "${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}.${IDF_VERSION_PATCH}")
+
+if (IDF_VERSION VERSION_GREATER_EQUAL "5.2.0")
+    list(APPEND SDKCONFIG_DEFAULTS ${MICROPY_PORT_DIR}/boards/sdkconfig.idf52)
+    message(STATUS "Adding the SDK config, final list is: ${SDKCONFIG_DEFAULTS}")
+endif()
+
 
 # Set the user C modules to include in the build.
 set(USER_C_MODULES

--- a/src/cmodules/cexample/modcexample.c
+++ b/src/cmodules/cexample/modcexample.c
@@ -2,7 +2,7 @@
 #include "py/runtime.h"
 
 // This is the function which will be called from Python as cexample.add_ints(a, b).
-STATIC mp_obj_t example_add_ints(mp_obj_t a_obj, mp_obj_t b_obj) {
+static mp_obj_t example_add_ints(mp_obj_t a_obj, mp_obj_t b_obj) {
     // Extract the ints from the micropython input objects.
     int a = mp_obj_get_int(a_obj);
     int b = mp_obj_get_int(b_obj);
@@ -11,18 +11,18 @@ STATIC mp_obj_t example_add_ints(mp_obj_t a_obj, mp_obj_t b_obj) {
     return mp_obj_new_int(a + b);
 }
 // Define a Python reference to the function above.
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(example_add_ints_obj, example_add_ints);
+static MP_DEFINE_CONST_FUN_OBJ_2(example_add_ints_obj, example_add_ints);
 
 // Define all properties of the module.
 // Table entries are key/value pairs of the attribute name (a string)
 // and the MicroPython object reference.
 // All identifiers and strings are written as MP_QSTR_xxx and will be
 // optimized to word-sized integers by the build system (interned strings).
-STATIC const mp_rom_map_elem_t example_module_globals_table[] = {
+static const mp_rom_map_elem_t example_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_cexample) },
     { MP_ROM_QSTR(MP_QSTR_add_ints), MP_ROM_PTR(&example_add_ints_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(example_module_globals, example_module_globals_table);
+static MP_DEFINE_CONST_DICT(example_module_globals, example_module_globals_table);
 
 // Define module object.
 const mp_obj_module_t example_user_cmodule = {

--- a/src/cmodules/cexample2/modcexample2.c
+++ b/src/cmodules/cexample2/modcexample2.c
@@ -1,17 +1,17 @@
 #include "py/runtime.h"
 
-STATIC mp_obj_t example_sub_ints(mp_obj_t a_obj, mp_obj_t b_obj) {
+static mp_obj_t example_sub_ints(mp_obj_t a_obj, mp_obj_t b_obj) {
     int a = mp_obj_get_int(a_obj);
     int b = mp_obj_get_int(b_obj);
     return mp_obj_new_int(a - b);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(example_sub_ints_obj, example_sub_ints);
+static MP_DEFINE_CONST_FUN_OBJ_2(example_sub_ints_obj, example_sub_ints);
 
-STATIC const mp_rom_map_elem_t example_module_globals_table[] = {
+static const mp_rom_map_elem_t example_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_cexample2) },
     { MP_ROM_QSTR(MP_QSTR_sub_ints), MP_ROM_PTR(&example_sub_ints_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(example_module_globals, example_module_globals_table);
+static MP_DEFINE_CONST_DICT(example_module_globals, example_module_globals_table);
 
 const mp_obj_module_t example_user_cmodule2 = {
     .base = { &mp_type_module },


### PR DESCRIPTION
This requires handling the following upstream commits: decf8e6a8b all: Remove the "STATIC" macro and just use "static" instead. 27279e69b4 esp32: Add IDF-version-specific sdkconfig. and, importantly
acbdbcd95e  esp32: Workaround IDF issue placing ISR ringbuf functions in IRAM

Replacing STATIC was easy.  Adding the IDF version specific was just implemented as upstream.
However, the new linker.lf files are not in a path that is being searched properly. I believe this can only be fixed in micropython itself by providing a better file reference.

The suggested upstream fix is available here: https://github.com/micropython/micropython/pull/16658 and is _required_ for this patch.

This supersedes: https://github.com/micropython/micropython-example-boards/pull/3 (it uses/relies on a different solution with upstream)
