### PR TITLE
Update to micropython 1.27.0 (minimal)

### DIFF
--- a/boards/CUSTOM_ESP32/main/CMakeLists.txt
+++ b/boards/CUSTOM_ESP32/main/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Include MicroPython ESP32 component.
 get_filename_component(MICROPY_DIR "../../../lib/micropython" ABSOLUTE)
 set(PROJECT_DIR ${MICROPY_DIR}/ports/esp32)
-include(${PROJECT_DIR}/main_esp32/CMakeLists.txt)
+include(${PROJECT_DIR}/main/CMakeLists.txt)

--- a/boards/CUSTOM_ESP32/main/idf_component.yml
+++ b/boards/CUSTOM_ESP32/main/idf_component.yml
@@ -3,3 +3,8 @@ dependencies:
   espressif/mdns: "~1.1.0"
   idf:
     version: ">=5.0.2"
+  espressif/lan867x:
+    version: "~1.0"
+    rules:
+      - if: "target == esp32"
+      - if: "idf_version >=5.3"

--- a/boards/CUSTOM_ESP32/mpconfigboard.cmake
+++ b/boards/CUSTOM_ESP32/mpconfigboard.cmake
@@ -6,6 +6,8 @@ set(SDKCONFIG_DEFAULTS
     ${MICROPY_PORT_DIR}/boards/sdkconfig.base
     ${MICROPY_PORT_DIR}/boards/sdkconfig.ble
 )
+include($ENV{IDF_PATH}/tools/cmake/version.cmake)
+set(IDF_VERSION "${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}.${IDF_VERSION_PATCH}")
 
 # Set the user C modules to include in the build.
 set(USER_C_MODULES

--- a/boards/CUSTOM_ESP32/partitions-4MiBplus.csv
+++ b/boards/CUSTOM_ESP32/partitions-4MiBplus.csv
@@ -1,7 +1,10 @@
+# This partition table is for devices with 4MiB or more of flash.
+# The first 2MiB is used for bootloader, nvs, phy_init and firmware.
+# The remaining flash is for the user filesystem(s).
+
 # Notes: the offset of the partition table itself is set in
 # $IDF_PATH/components/partition_table/Kconfig.projbuild.
 # Name,   Type, SubType, Offset,  Size, Flags
 nvs,      data, nvs,     0x9000,  0x6000,
 phy_init, data, phy,     0xf000,  0x1000,
 factory,  app,  factory, 0x10000, 0x1F0000,
-vfs,      data, fat,     0x200000, 0x200000,

--- a/src/cmodules/cexample/modcexample.c
+++ b/src/cmodules/cexample/modcexample.c
@@ -2,7 +2,7 @@
 #include "py/runtime.h"
 
 // This is the function which will be called from Python as cexample.add_ints(a, b).
-STATIC mp_obj_t example_add_ints(mp_obj_t a_obj, mp_obj_t b_obj) {
+static mp_obj_t example_add_ints(mp_obj_t a_obj, mp_obj_t b_obj) {
     // Extract the ints from the micropython input objects.
     int a = mp_obj_get_int(a_obj);
     int b = mp_obj_get_int(b_obj);
@@ -11,18 +11,18 @@ STATIC mp_obj_t example_add_ints(mp_obj_t a_obj, mp_obj_t b_obj) {
     return mp_obj_new_int(a + b);
 }
 // Define a Python reference to the function above.
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(example_add_ints_obj, example_add_ints);
+static MP_DEFINE_CONST_FUN_OBJ_2(example_add_ints_obj, example_add_ints);
 
 // Define all properties of the module.
 // Table entries are key/value pairs of the attribute name (a string)
 // and the MicroPython object reference.
 // All identifiers and strings are written as MP_QSTR_xxx and will be
 // optimized to word-sized integers by the build system (interned strings).
-STATIC const mp_rom_map_elem_t example_module_globals_table[] = {
+static const mp_rom_map_elem_t example_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_cexample) },
     { MP_ROM_QSTR(MP_QSTR_add_ints), MP_ROM_PTR(&example_add_ints_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(example_module_globals, example_module_globals_table);
+static MP_DEFINE_CONST_DICT(example_module_globals, example_module_globals_table);
 
 // Define module object.
 const mp_obj_module_t example_user_cmodule = {

--- a/src/cmodules/cexample2/modcexample2.c
+++ b/src/cmodules/cexample2/modcexample2.c
@@ -1,17 +1,17 @@
 #include "py/runtime.h"
 
-STATIC mp_obj_t example_sub_ints(mp_obj_t a_obj, mp_obj_t b_obj) {
+static mp_obj_t example_sub_ints(mp_obj_t a_obj, mp_obj_t b_obj) {
     int a = mp_obj_get_int(a_obj);
     int b = mp_obj_get_int(b_obj);
     return mp_obj_new_int(a - b);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(example_sub_ints_obj, example_sub_ints);
+static MP_DEFINE_CONST_FUN_OBJ_2(example_sub_ints_obj, example_sub_ints);
 
-STATIC const mp_rom_map_elem_t example_module_globals_table[] = {
+static const mp_rom_map_elem_t example_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_cexample2) },
     { MP_ROM_QSTR(MP_QSTR_sub_ints), MP_ROM_PTR(&example_sub_ints_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(example_module_globals, example_module_globals_table);
+static MP_DEFINE_CONST_DICT(example_module_globals, example_module_globals_table);
 
 const mp_obj_module_t example_user_cmodule2 = {
     .base = { &mp_type_module },


### PR DESCRIPTION
This requires handling the following upstream commits: decf8e6a8b all: Remove the "STATIC" macro and just use "static" instead.

This builds on prior work updating to 1.23 and 1.24

Only working ESP-IDF versions are 5.5.1 and 5.5.2. Current micropython uses the newest version of the touch sens driver, introduced in 5.5.x.  5.5.3 has a compile failure in nimble, best guess is upstream commit
https://github.com/espressif/esp-idf/commit/d6da79db085ff13b8cd5cff61c5962acc003a01e is causing problems, but not clear yet.

Runtime Tested on esp32 and esp32-s3 (local custom board using this patchset, plus extra usb changes not applicable to this repo)

Vs #5, this is self contained to just update the current repo, and is based on #3 and #4